### PR TITLE
pytest 5.3.5 is too old

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,3 +1,3 @@
-pytest==5.3.5
+pytest==6.2.5
 python-dateutil==2.8.1
 pytest-json-report==1.2.1


### PR DESCRIPTION
It is broken in recent versions of Python, like Python 11.  See https://github.com/pytest-dev/pytest/discussions/9195 . pytest 6.2.5 seems to work.